### PR TITLE
Disable background build scan upload

### DIFF
--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -3,6 +3,7 @@
         <url>http://localhost:8080</url>
     </server>
     <buildScan>
+        <backgroundBuildScanUpload>false</backgroundBuildScanUpload>
         <termsOfService>
             <url>https://gradle.com/terms-of-service</url>
             <accept>true</accept>


### PR DESCRIPTION
It is convenient to have it disabled by default when running on CI.